### PR TITLE
Delayed opening for junior sign-up

### DIFF
--- a/include/signup/config/main.json
+++ b/include/signup/config/main.json
@@ -93,11 +93,5 @@
     "dkk": {
         "en": "DKK",
         "da": "kr."
-    },
-    "no_edit": [
-        "signup_end",
-        "con_start",
-        "autocomplete",
-        "current_financial_support"
-    ]
+    }
 }

--- a/include/signup/pages/practical.json
+++ b/include/signup/pages/practical.json
@@ -299,7 +299,7 @@
                         {
                             "value": "Juniordeltager",
                             "text": {
-                                "en": "I want to participate in Fastaval Junior (230 kr.)\u00a0 [b]not available in english[\/b]",
+                                "en": "I want to participate in Fastaval Junior (230 kr.) [b]not available in english[\/b]",
                                 "da": "Jeg vil gerne deltage i Fastaval Junior (230 kr.) - For b\u00f8rn fra 6 til 14 \u00e5r"
                             },
                             "display_logic": [
@@ -321,6 +321,33 @@
                                     "config": "junior_closed",
                                     "compare": "equals",
                                     "value": true
+                                },
+                                {
+                                    "type": "config",
+                                    "status": "hidden",
+                                    "config": "junior_signup_open",
+                                    "compare": "equals",
+                                    "value": false
+                                }
+                            ]
+                        },
+                        {
+                            "value": "",
+                            "text": {
+                                "en": "Fastaval Junior signup opens [replace]junior_signup_time[/replace] [b]not available in english[\/b]",
+                                "da": "Tilmeldingen til Fastaval Junior åbner først d. [replace]junior_signup_time[/replace]"
+                            },
+                            "display_logic": [
+                                {
+                                    "type": "default",
+                                    "status": "hidden"
+                                },
+                                {
+                                    "type": "config",
+                                    "status": "disabled",
+                                    "config": "junior_signup_open",
+                                    "compare": "equals",
+                                    "value": false
                                 }
                             ]
                         },

--- a/public/js/signup/preprocess.js
+++ b/public/js/signup/preprocess.js
@@ -2,19 +2,19 @@
 
 class InfosysTextPreprocessor {
   // Preprocess text
-  static process_text(text) {
+  static process_text(text, lang, config) {
     text = jQuery('<div>'+text+'</div>').text(); //strip any HTML
     let match;
     let regex = /\[(\w+)(?:=([^\]]+))?\](.*?)\[\/\1\]/s;
     for (match = text.match(regex); match; match = text.match(regex)) {
-      text = this.processMatch(text, match);
+      text = this.processMatch(text, match, lang, config);
     }
     text = text.replaceAll("\n", "<br>");
     
     return text;
   }
 
-  static processMatch(text, match) {
+  static processMatch(text, match, lang, config) {
     switch (match[1]) {
       case "email":
         return text.replace(match[0], '<a href="mailto:'+match[3]+'">'+match[3]+'</a>');
@@ -31,6 +31,9 @@ class InfosysTextPreprocessor {
         bgcolor = bgcolor ?? "white";
         color = color ?? "black";
         return text.replace(match[0], '<span style="background-color:'+bgcolor+';color:'+color+';">'+match[3]+'</span>');
+
+      case "replace":
+        return text.replace(match[0], config.text_replacement[match[3]][lang]);
 
       default:
         console.log("Unknown token", match);

--- a/public/js/signup/render.js
+++ b/public/js/signup/render.js
@@ -3,10 +3,10 @@
 class InfosysSignupRender {
   static render_element(item, lang, config) {
     let html;
-    item.processed = InfosysTextPreprocessor.process_text(item.text[lang]);
+    item.processed = InfosysTextPreprocessor.process_text(item.text[lang], lang, config);
     
     if(typeof this['render_'+item.type] === 'function') {
-      html = this['render_'+item.type](item, lang);
+      html = this['render_'+item.type](item, lang, config);
     } else {
       html = this.render_unknown(item.processed, item.type)
     }
@@ -53,7 +53,7 @@ class InfosysSignupRender {
     if (item.errors) {
       for(const error in item.errors) {
         let error_div = jQuery('<div class="error-text" error-type="'+error+'"></div>');
-        let error_text = InfosysTextPreprocessor.process_text(item.errors[error][lang]);
+        let error_text = InfosysTextPreprocessor.process_text(item.errors[error][lang], lang, config);
         error_div.html(error_text);
         error_div.hide();
         if(item.type == 'checkbox') {
@@ -147,21 +147,21 @@ class InfosysSignupRender {
     `;
   }
 
-  static render_radio(item, lang) {
+  static render_radio(item, lang, config) {
     let div = jQuery('<div class="input-wrapper input-type-radio"></div>');
     div.append(`<p>${item.processed}</p>`);
     let hidden = jQuery(`<input type="hidden" id="${item.infosys_id}">`);
 
     item.options.forEach(function(element, index)  {
-      div.append(this.render_radio_option(item.infosys_id, index, element, lang));
+      div.append(this.render_radio_option(item.infosys_id, index, element, lang, config));
       if (element.default) hidden.val(element.value);
     }, this);
     div.append(hidden);
     return div.prop('outerHTML');
   }
 
-  static render_radio_option(id, index, element, lang) {
-    let text = InfosysTextPreprocessor.process_text(element.text[lang])
+  static render_radio_option(id, index, element, lang, config) {
+    let text = InfosysTextPreprocessor.process_text(element.text[lang], lang, config)
     let checked = element.default ? "checked" : "";
     return `
       <div class="input-wrapper input-type-radio-option">


### PR DESCRIPTION
- FIXED moved signup main config no_edit to getConfig() and added missing options
- ADDED values for junior signup start times to main config
- ADDED radio option on practical page to show junior signup isn't open yet
- ADDED text replacement functionality to signup render and preprocess